### PR TITLE
Preserve executable bit

### DIFF
--- a/src/nl/itimmer/amifirm/AmiFirm.java
+++ b/src/nl/itimmer/amifirm/AmiFirm.java
@@ -353,7 +353,7 @@ public class AmiFirm {
 	}
 	
 	public static void main(String args[]) {
-		System.out.println("AmiFirm 0.2.0 - Amino Aminet Firmware downloader and extractor");
+		System.out.println("AmiFirm 0.2.1 - Amino Aminet Firmware downloader and extractor");
 
 		int port = 0;
 		InetAddress address = null;

--- a/src/nl/itimmer/amifirm/AmiFirm.java
+++ b/src/nl/itimmer/amifirm/AmiFirm.java
@@ -330,7 +330,7 @@ public class AmiFirm {
 
 					// set file executable bit
 					if(fileIsExecutableMap.get(fileId)) {
-						file.setExecutable(true);
+						file.setExecutable(true, false);
 					}
 				} else {
 					System.err.println(fileName + " not found in firmware");


### PR DESCRIPTION
Simple PR to check whether or not the original file is executable. Useful for when rebuilding the firmware as the permissions must be correct in order for the amino to work with the firmware properly.